### PR TITLE
Fix: included post description meta

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{{ site.description }}">
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 	<meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}{{ site.keywords }}{% endif %}">
     <title>{% if page.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
 	 

--- a/_posts/2017-05-10-how-social-media-changes-quality-of-your-photos.markdown
+++ b/_posts/2017-05-10-how-social-media-changes-quality-of-your-photos.markdown
@@ -5,6 +5,7 @@ subtitle:   "because they need to reduce the load time of your photos."
 date:       2017-05-10 12:00:00
 author:     "Vijay Koushik"
 keywords:   "data compression, social media, image quality, svijaykoushik, blog, topic of interest"
+description: "I explain how social media apps reduce quality of photos to shorten the download time"
 header-img: "img/post-bg-01.jpg"
 og_type: 	"article"
 comments:   true


### PR DESCRIPTION
The site was initially showing the site description irrespective of the
post in the meta data

This would reduce the visibility of the posts in search engine as it
lacks relevant meta description

I've added a condition to show the post description if the page is an
article