### PR TITLE
Corrected the credit text in several pages

### DIFF
--- a/_posts/2017-05-10-how-social-media-changes-quality-of-your-photos.markdown
+++ b/_posts/2017-05-10-how-social-media-changes-quality-of-your-photos.markdown
@@ -12,7 +12,7 @@ comments:   true
 pageId:     "2017-05-10-how-social-media-changes-quality-of-your-photos"
 tags:       ["data-compression", "socia-lmedia", "image-quality", "topic-of-interest"]
 creditCover: true
-creditText: "&copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
+creditText: "Cover Photo / &copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
 ---
 <h1>Data Compression: How social media changes quality of your photos</h1>
 <p>In a world, where smart phones have dual cameras that take high quality pictures with precision, how are those images shared instantly? We all know that higher the quality of the picture, higher is its file size. So, how do we share megabytes of data in a blink of an eye?</p>

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@ description: "This is what I do."
 keywords:   "svijaykoushik, blog, about, author"
 header-img: "img/about-bg.jpg"
 creditCover: true
-creditText: "&copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
+creditText: "Cover Photo / &copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
 ---
 
 <p>A developer by hobby, A computer geek, passionate in User Interface and User Experience designing. I love to create programs because, it's fun!&nbsp;<i class="fa fa-smile-o"></i>

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@ description: "Have questions? Feel free to contact me."
 keywords:   "svijaykoushik, blog, contact"
 header-img: "img/contact-bg.jpg"
 creditCover: true
-creditText: "&copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
+creditText: "Cover Photo / &copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
 ---
 
 <p>Want to get in touch with me? You can find me on the web in the following locations</p>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: page
 title: "Learn from my personal experience"
 description: "Don't make the same mistakes I made"
 creditCover: true
-creditText: "&copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
+creditText: "Cover Photo / &copy; 2013-2016 Blackrock Digital LLC, used under a MIT license"
 ---
 
 {% for post in paginator.posts %}


### PR DESCRIPTION
Corrected the credit text  by including the name of the work which is being credited to.
 Before the change the pages index, contact, and about pages and the article social media compresses photos  the credit text made it look like the entire page was (c) to the image owner